### PR TITLE
Make stop sequence configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Send a POST request to `http://localhost:8080/api` with the following JSON body:
 ```json
 {
     "prompt": "# hello world function\n\n",
-    "language": "python"
+    "language": "python",
+    "stop": ["\n"]
 }
 ```
 
@@ -27,5 +28,7 @@ The response will be a plain text string containing the generated code.
 ```text
 def hello_world():
 ```
+
+The `stop` field is optional and defaults to `["\n"]` when omitted. Use it to control where completions should stop.
 
 In order to build a complete code snippet, iteratively append the generated code to the prompt and send it back to the API until the response is empty.

--- a/api.py
+++ b/api.py
@@ -82,7 +82,7 @@ def token_thread():
         get_token()
         time.sleep(25 * 60)
     
-def copilot(prompt, language='python'):
+def copilot(prompt, language='python', stop=None):
     global token
     # If the token is None, get a new one
     if token is None or is_token_invalid(token):
@@ -96,7 +96,7 @@ def copilot(prompt, language='python'):
             'temperature': 0,
             'top_p': 1,
             'n': 1,
-            'stop': ['\n'],
+            'stop': stop or ['\n'],
             'nwo': 'github/copilot.vim',
             'stream': True,
             'extra': {
@@ -149,9 +149,10 @@ class HTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         # Get the prompt from the request body
         prompt = body_json.get('prompt')
         language = body_json.get('language', 'python')
+        stop = body_json.get('stop', ['\n'])
 
         # Get the completion from the copilot function
-        completion = copilot(prompt, language)
+        completion = copilot(prompt, language, stop)
 
         # Send the completion as the response
         self.send_response(200)


### PR DESCRIPTION
## Summary
- add `stop` parameter to `copilot` function
- allow `stop` key in API requests
- document `stop` usage in README

## Testing
- `python3 -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_6889e4e46c188333962efdd3a78950b4