### PR TITLE
Add web UI and static file serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Provides a simple HTTP API to interface with GitHub Copilot, including native Gi
 ## Run
 `python3 api.py [port]`
 
+By default the application listens on port `8080`. After starting the server you
+can open `http://localhost:8080/` in your browser to use a simple chat page that
+talks to the API.
+
 ## Usage
 Send a POST request to `http://localhost:8080/api` with the following JSON body:
 
@@ -32,3 +36,7 @@ def hello_world():
 The `stop` field is optional and defaults to `["\n"]` when omitted. Use it to control where completions should stop.
 
 In order to build a complete code snippet, iteratively append the generated code to the prompt and send it back to the API until the response is empty.
+
+### Web UI
+
+There is a minimal browser-based interface in the `static/` folder. Once the server is running, visit [http://localhost:8080/](http://localhost:8080/) to send prompts and view completions.

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Copilot API Chat</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        #messages { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; height: 200px; overflow-y: auto; margin-top: 20px; }
+        textarea { width: 100%; }
+    </style>
+</head>
+<body>
+    <h1>Copilot Chat</h1>
+    <textarea id="prompt" rows="4" placeholder="Enter your prompt"></textarea><br>
+    <button id="send">Send</button>
+    <div id="messages"></div>
+<script>
+document.getElementById('send').addEventListener('click', async () => {
+    const prompt = document.getElementById('prompt').value;
+    if (!prompt) return;
+    try {
+        const resp = await fetch('/api', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt })
+        });
+        const text = await resp.text();
+        const messages = document.getElementById('messages');
+        messages.textContent += text + '\n';
+        document.getElementById('prompt').value = '';
+    } catch (err) {
+        alert('Request failed: ' + err);
+    }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static files and limit `/api` POSTs to that path
- add simple chat UI under `static/`
- document web UI in README

## Testing
- `python3 -m py_compile api.py`
- *(fails: server requires GitHub authentication)*

------
https://chatgpt.com/codex/tasks/task_e_6889e5af4360833383a27505e1fa2e6c