### PR TITLE
Remove stop parameter and refresh UI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 B00TK1D
+Copyright (c) 2024 Mahesh Dadi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 # Copilot.api
 
-Provides a simple HTTP API to interface with GitHub Copilot, including native GitHub authentication.
+Provides a simple HTTP API to interface with GitHub Copilot, including native GitHub authentication.  It exposes OpenAI compatible endpoints so that tools such as [Open WebUI](https://github.com/open-webui/open-webui) can talk to Copilot.
 
 ## Installing dependencies
 
 `pip install -r requirements.txt`
 
 ## Run
+Run the server on the desired port (defaults to `8080`):
 `python3 api.py [port]`
 
-The server also exposes OpenAI-compatible endpoints under `/v1` so that tools
-like [Open WebUI](https://github.com/open-webui/open-webui) can connect. Use the
-following environment variables when starting Open WebUI:
+The server exposes OpenAI‑compatible endpoints under `/v1` so that tools like
+[Open WebUI](https://github.com/open-webui/open-webui) can connect.  When
+starting Open WebUI use the following environment variables:
 
 ```
 OPENAI_API_BASE_URLS=http://host.docker.internal:8080/v1
 OPENAI_API_KEYS=dummy
 ```
 
-Point your browser to `http://localhost:8080/` for a minimal chat UI.
+Point your browser to `http://localhost:8080/` for a small fallback UI that works
+in any modern browser.  It can be useful when you do not have Open WebUI running.
 
 ## Usage
 Send a POST request to `http://localhost:8080/api` with the following JSON body:
@@ -27,8 +29,7 @@ Send a POST request to `http://localhost:8080/api` with the following JSON body:
 ```json
 {
     "prompt": "# hello world function\n\n",
-    "language": "python",
-    "stop": ["\n"]
+    "language": "python"
 }
 ```
 
@@ -40,6 +41,6 @@ The response will be a plain text string containing the generated code.
 def hello_world():
 ```
 
-The `stop` field is optional and defaults to `["\n"]` when omitted. Use it to control where completions should stop. Omit the field entirely to allow multiline responses.
+
 
 In order to build a complete code snippet, iteratively append the generated code to the prompt and send it back to the API until the response is empty.

--- a/api.py
+++ b/api.py
@@ -104,7 +104,7 @@ def token_thread():
         get_token()
         time.sleep(25 * 60)
     
-def copilot(prompt, language='python', stop=None):
+def copilot(prompt, language='python'):
     """Request a completion from GitHub Copilot."""
     global token
     # If the token is None, get a new one
@@ -119,7 +119,6 @@ def copilot(prompt, language='python', stop=None):
             'temperature': 0,
             'top_p': 1,
             'n': 1,
-            'stop': stop or ['\n'],
             'nwo': 'github/copilot.vim',
             'stream': True,
             'extra': {
@@ -197,10 +196,9 @@ class HTTPRequestHandler(http.server.BaseHTTPRequestHandler):
 
         if self.path == "/v1/chat/completions":
             messages = body_json.get("messages", [])
-            stop = body_json.get("stop")
             language = body_json.get("language", "python")
             prompt = build_prompt(messages)
-            completion = copilot(prompt, language, stop)
+            completion = copilot(prompt, language)
             response = {
                 "choices": [
                     {
@@ -217,8 +215,7 @@ class HTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         # default /api compatibility
         prompt = body_json.get("prompt")
         language = body_json.get("language", "python")
-        stop = body_json.get("stop")
-        completion = copilot(prompt, language, stop)
+        completion = copilot(prompt, language)
         self.send_response(200)
         self.send_header("Content-type", "text/plain")
         self.end_headers()

--- a/static/index.html
+++ b/static/index.html
@@ -4,9 +4,25 @@
   <meta charset="utf-8" />
   <title>Copilot Chat</title>
   <style>
-    body { font-family: sans-serif; margin: 2em; }
-    #chat { border: 1px solid #ccc; padding: 1em; height: 300px; overflow-y: auto; }
-    #prompt { width: 80%; }
+    body {
+      font-family: sans-serif;
+      margin: 2em;
+      max-width: 700px;
+    }
+    #chat {
+      border: 1px solid #ccc;
+      padding: 1em;
+      height: 300px;
+      overflow-y: auto;
+      margin-bottom: 1em;
+      white-space: pre-wrap;
+    }
+    .user {
+      font-weight: bold;
+    }
+    #prompt {
+      width: 80%;
+    }
   </style>
 </head>
 <body>
@@ -16,25 +32,38 @@
   <button id="send">Send</button>
   <script>
     const chat = document.getElementById('chat');
-    document.getElementById('send').onclick = async () => {
+
+    async function send() {
       const input = document.getElementById('prompt');
-      const prompt = input.value;
+      const prompt = input.value.trim();
       input.value = '';
       if (!prompt) return;
+
       const userDiv = document.createElement('div');
       userDiv.textContent = 'You: ' + prompt;
+      userDiv.className = 'user';
       chat.appendChild(userDiv);
+
       const resp = await fetch('/api', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt })
       });
+
       const text = await resp.text();
       const botDiv = document.createElement('div');
       botDiv.textContent = 'Bot: ' + text;
       chat.appendChild(botDiv);
       chat.scrollTop = chat.scrollHeight;
-    };
+    }
+
+    document.getElementById('send').addEventListener('click', send);
+    document.getElementById('prompt').addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        send();
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop `stop` parameter handling from server
- update README with instructions and new request format
- improve fallback chat UI
- change license holder to Mahesh Dadi

## Testing
- `python3 -m py_compile api.py`


------
https://chatgpt.com/codex/tasks/task_e_6889f3086b708333b4c1041beacbc21b